### PR TITLE
chore: pnpm approve-builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
   "packageManager": "pnpm@10.4.1",
   "engines": {
     "node": ">=20"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "core-js-pure",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
Simply running `pnpm approve-builds` and updating the `onlyBuiltDependencies` within `package.json`.