### PR TITLE
chore: disable nextjs build telemetry

### DIFF
--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/checkout@v4
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,9 @@
 # TODO
 
 - [x] Add [nextjs-bundle-analysis](https://github.com/hashicorp/nextjs-bundle-analysis) to the PR CI process
-- [ ] Fix ESLint error: Cannot find package '@eslint/js' in packages/eslint-config
+- [x] Fix ESLint error: Cannot find package '@eslint/js' in packages/eslint-config
 - [ ] Configure Next.js build caching for faster CI builds
 - [ ] Fix cache path validation error in GitHub Actions workflow
 - [ ] Setup [CodeCov](https://app.codecov.io/)
 - [ ] Setup LightHouseCI diff based on Vercels LightHouse CI reports, using [this](https://github.com/marketplace/actions/lighthouse-compare) and [this](https://github.com/marketplace/actions/vercel-preview-url-lighthouse-audit). We want the diff which I doubt the Vercel one does.
+- [x] Disable NextJS telemetry


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow to disable Next.js telemetry during bundle analysis.
  - Updated TODO list to reflect completed tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->